### PR TITLE
Refactor particle animations to use GPU shaders for performance.

### DIFF
--- a/src/components/ui/ShaderPoints.tsx
+++ b/src/components/ui/ShaderPoints.tsx
@@ -1,0 +1,52 @@
+import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
+import { useMemo, useRef } from 'react';
+
+// Define the props for our component
+interface ShaderPointsProps {
+  geometry: THREE.BufferGeometry;
+  vertexShader: string;
+  fragmentShader: string;
+  uniforms: { [key: string]: { value: any } };
+  pointSize?: number;
+  blending?: THREE.Blending;
+  transparent?: boolean;
+  depthWrite?: boolean;
+}
+
+export const ShaderPoints = ({
+  geometry,
+  vertexShader,
+  fragmentShader,
+  uniforms,
+  pointSize = 1.0,
+  ...rest // Pass down other material properties like blending, transparent, etc.
+}: ShaderPointsProps) => {
+  const materialRef = useRef<THREE.ShaderMaterial>(null!);
+
+  // Memoize the uniforms object to prevent re-creations
+  const memoizedUniforms = useMemo(() => ({
+    u_time: { value: 0 },
+    u_size: { value: pointSize },
+    ...uniforms,
+  }), [uniforms, pointSize]);
+
+  useFrame(({ clock }) => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.u_time.value = clock.getElapsedTime();
+    }
+  });
+
+  return (
+    <points geometry={geometry}>
+      <shaderMaterial
+        ref={materialRef}
+        uniforms={memoizedUniforms}
+        vertexShader={vertexShader}
+        fragmentShader={fragmentShader}
+        vertexColors={true}
+        {...rest}
+      />
+    </points>
+  );
+};


### PR DESCRIPTION
This commit significantly improves the performance and smoothness of the 3D simulation by offloading expensive particle animations from the CPU to the GPU.

Key changes:
- Introduced a new reusable `ShaderPoints` component to abstract the use of `THREE.ShaderMaterial` for point clouds.
- Refactored `PhysicalBrain.tsx` to move its neuron firing color animation into a GLSL fragment shader.
- Refactored `HigherMind.tsx` to move its particle position and color pulsing animation into GLSL vertex and fragment shaders.
- Implemented the previously missing particle animation in `PhysicalMind.tsx`, creating a swirling motion using a vertex shader.